### PR TITLE
fix(core): remove cdylib to prevent dylib crash on launch

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ description = "Gõ Việt - Vietnamese input method core engine"
 
 [lib]
 name = "goxviet_core"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 # Minimal dependencies for core engine


### PR DESCRIPTION
## 🚨 Hotfix: GoxViet crashes on launch — `Library not loaded: libgoxviet_core.dylib`

### Problem

Users reported the app crashes immediately on launch with:

> **"GoxViet cannot be opened because of a problem."**

The crash report (`EXC_CRASH / SIGABRT`) showed:

```
Library not loaded: /Users/runner/work/goxviet-ime/goxviet-ime/core/target/x86_64-apple-darwin/release/deps/libgoxviet_core.dylib
Reason: tried: '/Users/*/libgoxviet_core.dylib' (no such file)
```

### Root Cause

`core/Cargo.toml` had:

```toml
crate-type = ["staticlib", "cdylib", "rlib"]
```

When Cargo builds both `staticlib` and `cdylib` together, the `staticlib` (`.a`) embeds a dynamic reference to the intermediate `cdylib` in `target/.../release/deps/libgoxviet_core.dylib`. This path is hardcoded to the **CI build machine** at compile time.

When the `.a` is linked into the macOS app and distributed, the binary retains this hardcoded `LC_LOAD_DYLIB` entry pointing to the CI runner's path — which doesn't exist on any end-user machine.

### Fix

Remove `cdylib` from `crate-type`. macOS only needs `staticlib` and `rlib`:

```toml
# Before
crate-type = ["staticlib", "cdylib", "rlib"]

# After
crate-type = ["staticlib", "rlib"]
```

With only `staticlib`, Cargo produces a fully self-contained static archive with no dynamic self-references. The universal `.a` built via `lipo` and linked by Xcode has zero external Rust library dependencies.

### Verification

After the fix, `otool -L` on the app binary should **not** contain any `libgoxviet_core.dylib` line. All Rust code is statically embedded in the app binary.

```bash
# Clean build confirms only .a and .rlib are produced, no .dylib
$ cargo clean && cargo build --release
$ ls target/release/libgoxviet_core.*
target/release/libgoxviet_core.a
target/release/libgoxviet_core.rlib
```

### Files Changed

| File | Change |
|------|--------|
| `core/Cargo.toml` | Remove `cdylib` from `crate-type` |

### Impact

- ✅ Fixes crash on all end-user machines
- ✅ No behavior change — all functionality preserved
- ✅ Static linking is already the intended approach for macOS distribution
- ✅ Clean build produces smaller binary (no dylib overhead)

### Testing

- [x] `cargo clean && cargo build --release` — no `.dylib` produced
- [x] `cargo test` — all tests pass
- [x] Confirmed `libgoxviet_core.a` is a proper self-contained static archive
